### PR TITLE
!query patch

### DIFF
--- a/lorebot.js
+++ b/lorebot.js
@@ -1083,7 +1083,9 @@ function ProcessQuery(message)
                       match = /^([A-Za-z_\s]+)\s+by\s+([+-]?\d+(?:[A-Za-z_\s\d]+)?)$/.exec(affectsArr[i].trim());
                       if (match != null && match.length === 3) {      // think matching index [0,1,2] -> length = 3
                         half1 = match[1];
-                        half2 = match[2];
+                        var temphalf2 = match[2];
+                        half2 = temphalf2.replace(/\+/g, '\\\\\+');  // replaces all "+" with "\\+"
+                        
                         //console.log(`match[${i}]: ${half1} by ${half2}`);
                         whereClause += ` AND (Lore.${property.toUpperCase()} REGEXP '.*${half1}[[:space:]]+by[[:space:]]+${half2}.*' ) `
                       }
@@ -1105,7 +1107,9 @@ function ProcessQuery(message)
                     match = /^([A-Za-z_\s]+)\s+by\s+([+-]?\d+(?:[A-Za-z_\s\d]+)?)$/.exec(args[property].trim());
                     if (match != null && match.length === 3) {      // think matching index [0,1,2] -> length = 3
                       half1 = match[1];
-                      half2 = match[2];
+                      var temphalf2 = match[2];
+                      half2 = temphalf2.replace(/\+/g, '\\\\\+');  // replaces all "+" with "\\+"
+                      
                       //console.log(`match[${i}]: ${half1} by ${half2}`);
                       whereClause += ` AND (Lore.${property.toUpperCase()} REGEXP '.*${half1}[[:space:]]+by[[:space:]]+${half2}.*' ) `
                     }


### PR DESCRIPTION
the "+" in !query such as "spell slots by +1 at level 6" was throwing off the MySQL regex.  You need to double escape literal +'s when using MySQL so I added a quick patch that takes the half2 variable and before putting it into the SQL parser, double escapes any literal + signs.  I tested this using MySQL Workbench.

I also verified that in javascript, when using backtick's and $ to access the variables, the + did not seem to be processed any differently as any other letter in the string.  I do not think the problem was with Javascript's processing of the +, but rather, MySQL's which the double escape should resolve.

I figured it out from here:
https://stackoverflow.com/questions/15558172/mysql-regexp-whitespace-s