### PR TITLE
!query affects= patch

### DIFF
--- a/lorebot.js
+++ b/lorebot.js
@@ -1082,7 +1082,7 @@ function ProcessQuery(message)
                     if (/^([A-Za-z_\s]+)\s+by\s+([+-]?\d+(?:[A-Za-z_\s\d]+)?)$/.test(affectsArr[i].trim())) {
                       match = /^([A-Za-z_\s]+)\s+by\s+([+-]?\d+(?:[A-Za-z_\s\d]+)?)$/.exec(affectsArr[i].trim());
                       if (match != null && match.length === 3) {      // think matching index [0,1,2] -> length = 3
-                        half1 = match[1];
+                        half1 = match[1].trim();
                         var temphalf2 = match[2];
                         half2 = temphalf2.replace(/\+/g, '\\\\\+');  // replaces all "+" with "\\+"
                         
@@ -1106,7 +1106,7 @@ function ProcessQuery(message)
                   if (/^([A-Za-z_\s]+)\s+by\s+([+-]?\d+(?:[A-Za-z_\s\d]+)?)$/.test(args[property].trim())) {
                     match = /^([A-Za-z_\s]+)\s+by\s+([+-]?\d+(?:[A-Za-z_\s\d]+)?)$/.exec(args[property].trim());
                     if (match != null && match.length === 3) {      // think matching index [0,1,2] -> length = 3
-                      half1 = match[1];
+                      half1 = match[1].trim();
                       var temphalf2 = match[2];
                       half2 = temphalf2.replace(/\+/g, '\\\\\+');  // replaces all "+" with "\\+"
                       


### PR DESCRIPTION
trailing spaces following the word "gaze" in this example ( "skill gaze    by +10" ), were being included in the **half1** variable due to my previous patch that allowed the regex to match spaces for the **half1** variable so it could match "skill gaze" or "spell slots".  This was then transferring as literal spaces that showed up before the [[:space:]]+ in the MySQL REGEXP.  By removing the trailing white space with **.trim()**  from the **half1** variable it will enable the [[:space:]]+ to match any amount of white space between the skill name and its +'s since that seems to vary between some LORES.

I did testing in MySQL Workbench and a Javascript discord bot I have.