### PR TITLE
!query affects patch

### DIFF
--- a/lorebot.js
+++ b/lorebot.js
@@ -1028,7 +1028,7 @@ function ProcessQuery(message)
 
   //console.log(`${message.content.trim().length} : ${(config.prefix + "query").length}`);
   if (message.content.trim().length >(config.prefix + "query").length ) {
-    queryParams = message.content.trim().substring((config.prefix + "query").length,message.content.trim().length);
+    queryParams = message.content.trim().substring((config.prefix + "query").length,message.content.trim().length).replace(/\+/g, '%2B');
     queryParams = queryParams.trim();
     if (queryParams.indexOf("=") > 0 || queryParams.indexOf(">") > 0 || queryParams.indexOf("<") > 0)  {
       args = querystring.parse(queryParams.trim());


### PR DESCRIPTION
"querystring", which is a 3rd party app used to deconstruct URL's or in this case, the argument. In URL's you need to use %2B instead of "+" for proper handling.  When we were sending the + to query string it was returning a blank space, so technically the + was always being ignored.  by adding the .replace to the queryParam (before being processed by querystring) the output from querystring will include +'s which of course makes all my previous patches now work properly.