### PR TITLE
Fix for Level XX : SpellName (syntax repair)

### DIFF
--- a/lorebot.js
+++ b/lorebot.js
@@ -88,7 +88,7 @@ var parseLore = (pAuthor , pLore) => {
             attribValue = match[2].trim();
           }
 
-          let levelRegex = /^Level\s(\d+)$/;
+          let levelRegex = /^Level\s+(\d+)$/;
 		        if (levelRegex.test(attribName.trim())) {
 			      let levelnumber = levelRegex.exec(attribName.trim());
 			      attribName = "level";


### PR DESCRIPTION
missed a + on line 91.
would work with "Level 5 : SpellName" but not with "Level  5 : SpellName"  the + fixes that.